### PR TITLE
fix: forgot_password_title (key) in language packs

### DIFF
--- a/uploady/languages/ar.json
+++ b/uploady/languages/ar.json
@@ -49,7 +49,7 @@
         "token_expired_title": "انتهت صلاحية الرمز",
         "token_expired_head": "انتهت صلاحية الرمز",
         "token_expired_msg": "انتهت صلاحية رمزك المميز. حاول مرة اخرى.",
-        "forgot_password_title": "نسيت كلمة المرور",
+        "forget_password_title": "نسيت كلمة المرور",
         "forget_password_header": "نسيت كلمة المرور",
         "forget_password_h4": "نسيت كلمة المرور",
         "forget_password_msg": "يرجى إدخال عنوان بريدك الإلكتروني لإعادة تعيين كلمة المرور الخاصة بك.",

--- a/uploady/languages/en.json
+++ b/uploady/languages/en.json
@@ -49,7 +49,7 @@
     "token_expired_title": "Token Expired",
     "token_expired_head": "Token Expired",
     "token_expired_msg": "Your token has expired. Please try again.",
-    "forgot_password_title": "Forgot Password",
+    "forget_password_title": "Forgot Password",
     "forget_password_header": "Password Recovery",
     "forget_password_h4": "Forgot your password?",
     "forget_password_msg": "Enter your email address and we'll send you a link to reset your password.",

--- a/uploady/languages/it.json
+++ b/uploady/languages/it.json
@@ -49,7 +49,7 @@
     "token_expired_title": "Token Scaduto",
     "token_expired_head": "Token Scaduto",
     "token_expired_msg": "Il suo token è scaduto. Riprovare nuovamente.",
-    "forgot_password_title": "Password Dimenticata",
+    "forget_password_title": "Password Dimenticata",
     "forget_password_header": "Recupero Password",
     "forget_password_h4": "Hai dimenticato la password?",
     "forget_password_msg": "Inserisca la sua email e le verrà inviato il link per recuperare la password.",

--- a/uploady/languages/ru.json
+++ b/uploady/languages/ru.json
@@ -49,7 +49,7 @@
     "token_expired_title": "Токен истек",
     "token_expired_head": "Токен истек",
     "token_expired_msg": "Срок действия вашего токена истек. Пожалуйста, попробуйте еще раз.",
-    "forgot_password_title": "Пароль утерян",
+    "forget_password_title": "Пароль утерян",
     "forget_password_header": "Восстановление пароля",
     "forget_password_h4": "Забыли свой пароль?",
     "forget_password_msg": "Введите свой адрес электронной почты, и мы вышлем вам ссылку для сброса пароля.",


### PR DESCRIPTION
I changed forg**o**t_password_title key to forg**e**t_password_title in the language packs to avoid the display error:

![photo_2024-01-11_22-01-02](https://github.com/farisc0de/Uploady/assets/61466224/632ffff1-bff4-4434-9962-94d97808b03e)
